### PR TITLE
enable to work when called from <expr> mappings

### DIFF
--- a/autoload/ruby_hl_lvar.vim
+++ b/autoload/ruby_hl_lvar.vim
@@ -11,15 +11,15 @@ function! ruby_hl_lvar#redraw() abort
 	let nr = 1
 	let lastnr = winnr('$')
 	while nr <= lastnr
-		execute "normal! ".nr."\<C-w>w"
+		execute nr . "wincmd w"
 		call s:redraw_window()
 		let nr += 1
 	endwhile
 
 	if prevwinnr > 0
-		execute "normal! ".prevwinnr."\<C-w>w"
+		execute prevwinnr . "wincmd w"
 	endif
-	execute "normal! ".curwinnr."\<C-w>w"
+	execute curwinnr . "wincmd w"
 endfunction
 
 function! s:redraw_window()


### PR DESCRIPTION
`:help map-<expr>`

```
                                                *:map-<expr>* *:map-expression*
マップや短縮入力を定義するときに "<expr>" 引数を指定すると、引数が式 (スクリプ
ト) として扱われます。マップが実行されたときに、式が評価され、その値が {rhs}
として使われます。例: >
        :inoremap <expr> . InsertDot()
InsertDot() 関数の戻り値が挿入されます。カーソルの前のテキストをチェックして、
ある条件に一致するなら omni 補完を開始する、というようなことができます。

短縮入力では、入力されて短縮入力展開のトリガーとなった文字が |v:char| にセット
されます。これを使って {lhs} の展開方法を決めることもできます。自分で v:char
を挿入したり変更したりすべきではありません。

副作用に注意してください。式は文字の取得中に評価されるため、簡単に異常動作を起
こせてしまいます。そのため、次のものは制限されます:
- バッファのテキストの変更 |textlock|。
- 他のバッファの編集。
- |:normal| コマンド。
- カーソルの移動は可能ですが、後で元に戻されます。
以上のことを実現したい場合は、そのためのコマンド文字列を返してください。

............
```

とあり`<expr>`マップ内ではnormalコマンドを使用できません。

このプラグイン単体では`<expr>`マッピングされていないため問題はありません。
しかし、`TextChanged`イベントで`normal`コマンドを含む関数`ruby_hl_lvar#refresh()`が呼び出されており、`<expr>`マッピング内で`TextChanged`イベントが発生するプラグインが共存する場合うまく動作しません。

具体的な例としては、[neosnippet](https://github.com/Shougo/neosnippet.vim) でsnippetを展開するマッピングを`<expr>`で割り当てているとうまく動作しませんでした。


これに対応するために、`normal`コマンドを使用している部分を`wincmd`に書き換えました。手元ではneosnippetが正常に動作することを確認しました。