### PR TITLE
Prevent from refreshing in visual mode

### DIFF
--- a/autoload/ruby_hl_lvar.vim
+++ b/autoload/ruby_hl_lvar.vim
@@ -99,6 +99,9 @@ function! ruby_hl_lvar#refresh(force) abort
 	if !a:force && exists('b:ruby_hl_lvar_enabled') && !b:ruby_hl_lvar_enabled
 		return
 	endif
+	if mode() =~# "^[vV\<C-v>]"
+		return
+	endif
 	if exists('b:ruby_hl_lvar_match_pattern')
 		unlet b:ruby_hl_lvar_match_pattern
 	endif


### PR DESCRIPTION
Auto refreshing function triggered by TextChanged event is disabling https://github.com/t9md/vim-textmanip that continuously reselect previous selection.
This pull-req will check if in visual mode, and if so, it won't refresh (redraw) buffer.