### PR TITLE
Enable to work with compound filetype.

### DIFF
--- a/plugin/ruby_hl_lvar.vim
+++ b/plugin/ruby_hl_lvar.vim
@@ -28,7 +28,7 @@ function! Ruby_hl_lvar_filetype()
 	let groupname = 'vim_hl_lvar_'.bufnr('%')
 	execute 'augroup '.groupname
 		autocmd!
-		if &filetype ==# 'ruby'
+		if &filetype =~# '\<ruby\>'
 			if g:ruby_hl_lvar_auto_enable
 				call ruby_hl_lvar#refresh(1)
 				autocmd TextChanged <buffer> call ruby_hl_lvar#refresh(0)


### PR DESCRIPTION
For example, this plugin doesn't work when filetype is `ruby.rspec`.
Fixed this problem.

Blog article about compound filetype. http://vim-jp.org/vim-users-jp/2010/09/07/Hack-172.html

