### PR TITLE
Quiet warning.

### DIFF
--- a/autoload/ruby_hl_lvar.vim.rb
+++ b/autoload/ruby_hl_lvar.vim.rb
@@ -152,6 +152,12 @@ module RubyHlLvar
       r.on nil do
         []
       end
+      r.on 0 do
+        []
+      end
+      r.on [:rest_param, nil] do
+        []
+      end
       r.else do|obj|
         warn "Unsupported ast item in handle_rest_params: #{obj.inspect}"
         []


### PR DESCRIPTION
This plugin says `Unsupported ast item in handle_rest_params: [:rest_param, nil]` when I edit the following file.

```ruby
a{|*|}
```

Syntax tree of this file is the following text.



```ruby
[:program,
 [[:method_add_block,
   [:method_add_arg, [:fcall, [:@ident, "a", [1, 0]]], []],
   [:brace_block,
    [:block_var,
     [:params, nil, nil, [:rest_param, nil], nil, nil, nil, nil],
     false],
    [[:void_stmt]]]]]]
```

-----------------

This plugin says `Unsupported ast item in handle_rest_params: 0` when I edit the following file.

```ruby
a{|b,|}
```

Syntax tree of this file is the following text.

```ruby
[:program,
 [[:method_add_block,
   [:method_add_arg, [:fcall, [:@ident, "a", [1, 0]]], []],
   [:brace_block,
    [:block_var,
     [:params, [[:@ident, "b", [1, 3]]], nil, 0, nil, nil, nil, nil],
     false],
    [[:void_stmt]]]]]]
```
------

Command for Syntax tree.

```sh
ruby -rripper -rpp -e 'pp Ripper.sexp(ARGF.read)' a.rb
```


----------

This patch quiet those warnings by Adding rules.