### PR TITLE
Update massign.

### DIFF
--- a/autoload/ruby_hl_lvar.vim.rb
+++ b/autoload/ruby_hl_lvar.vim.rb
@@ -120,10 +120,16 @@ module RubyHlLvar
       r.on [:mlhs_add_star, p._1, p._2] do|m, _self|
         _self.handle_massign_lhs(m._1) + _self.handle_massign_lhs([m._2])
       end
-      r.on [:field, p._xs] do
+      r.on [:mlhs_add_star, p._1, p._2, p._3] do|m, _self|
+        _self.handle_massign_lhs(m._1) + _self.handle_massign_lhs([m._2]) + _self.handle_massign_lhs(m._3)
+      end
+      r.on [:aref_field, p._1, p._2] do |m, _self|
+        _self.extract_from_sexp(m._1) + _self.extract_from_sexp(m._2)
+      end
+      r.on [p.or(:field, :@ivar, :@cvar, :@gvar, :@const), p._xs] do
         []
       end
-      r.on [:@ivar, p._xs] do
+      r.on nil do
         []
       end
       r.else do|obj, _self|

--- a/spec/ruby-hl-lvar_spec.rb
+++ b/spec/ruby-hl-lvar_spec.rb
@@ -27,6 +27,9 @@ describe RubyHlLvar::Extractor do
     context 'complex mass assignment' do
       it { 'a, (b, c) = foo'.should_extract_to [['a', 1, 0], ['b', 1, 4], ['c', 1, 7]] }
       it { 'a, *b = foo'.should_extract_to [['a', 1, 0], ['b', 1, 4]] }
+      it { '*a, b = foo'.should_extract_to [['a', 1, 1], ['b', 1, 4]] }
+      it { 'a, *b, c = foo'.should_extract_to [['a', 1, 0], ['b', 1, 4], ['c', 1, 7]] }
+      it { "a = []\nb=1\na[0], a[b] = foo".should_extract_to [['a', 1, 0], ['b', 2, 0], ['a', 3, 0], ['a', 3, 6], ['b', 3, 8]]}
     end
 
     context "lhs of assignment" do


### PR DESCRIPTION
Support following massigns.

```ruby
a, *b, c     = a
*a, b, c     = a
a, *, c      = a
a[0], a[1]   = a
@@foo, @@bar = a
$foo, $bar   = a
FOO, BAR     = a
```