### PR TITLE
Handle normal params after rest params.

### DIFF
--- a/autoload/ruby_hl_lvar.vim.rb
+++ b/autoload/ruby_hl_lvar.vim.rb
@@ -90,6 +90,7 @@ module RubyHlLvar
         _self.handle_normal_params(m._1[0]) +
           _self.handle_default_params(m._1[1]) +
           _self.handle_rest_param(m._1[2]) +
+          _self.handle_normal_params(m._1[3]) +
           _self.handle_block_param(m._1[6])
       end
       r.on p.or(nil, true, false, Numeric, String, Symbol, []) do|m|


### PR DESCRIPTION
Ruby allows to put normal params after rest param.

for example.

http://docs.ruby-lang.org/ja/2.3.0/doc/spec=2fdef.html#method

```ruby
def f(a, *b, c)
end
```

This PR adds handling the normal params.





