### PR TITLE
Add a workaround of`:rubyfile` to avoid SEGV

### DIFF
--- a/autoload/ruby_hl_lvar.vim
+++ b/autoload/ruby_hl_lvar.vim
@@ -1,6 +1,6 @@
 let s:self_path=expand("<sfile>")
 
-execute 'rubyfile '.s:self_path.'.rb'
+execute 'ruby require "' . s:self_path . '.rb"'
 
 let s:hl_version = 0
 


### PR DESCRIPTION
Problem
==

`:rubyfile` SEGV on Linux.
See https://github.com/vim/vim/pull/2512 https://github.com/vim-jp/issues/issues/1138


Solution
==

Use `:ruby` instead of `:rubyfile`. 